### PR TITLE
Enhancements to update set picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Make Service-Now Great Again
+# Make ServiceNow Great Again
 
-This Chrome extension contains a variety of tweaks intended to improve the Service-Now user experience.
+This Chrome extension contains a variety of tweaks intended to improve the ServiceNow user experience.
 
 ## Included tweaks
 
@@ -8,4 +8,11 @@ This Chrome extension contains a variety of tweaks intended to improve the Servi
 
 ![QA and Dev favicons](https://i.imgur.com/12Rned0.png)
 
-Service-Now instances with names ending in ```qa``` or ```dev``` will have their favicons (icons displayed in the browser bar) changed to different icons so that Service-Now developers working in multiple environments can easily tell which tab is in which environment.
+ServiceNow instances with names ending in ```qa``` or ```dev``` will have their favicons (icons displayed in the browser bar) changed to different icons so that Service-Now developers working in multiple environments can easily tell which tab is in which environment.
+
+### Update set picker enhancements
+
+![New update set picker](https://i.imgur.com/abhtP8Z.png)
+
+* Click on the stacked paper icon on the right to copy the current update set name to the clipboard.
+* Click on the caret icon on the left to go to the current update set in ServiceNow.

--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,13 @@
     "tabs",
     "https://*.service-now.com/*"
   ],
-  "content_scripts": [],
+  "content_scripts": [
+    {
+      "matches": ["https://*.service-now.com/*"],
+      "css": ["src/inject/inject.css"],
+      "js": ["src/inject/inject.js", "js/jquery/jquery.min.js"]
+    }
+  ],
   "web_accessible_resources": [
     "icons/*.png"
   ]

--- a/src/bg/background.html
+++ b/src/bg/background.html
@@ -4,4 +4,7 @@
   <script type="text/javascript" src="background.js"></script>
   <script type="text/javascript" src="favicons.js"></script>
 </head>
+<body>
+  <textarea id="sandbox"></textarea>
+</body>
 </html>

--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -1,13 +1,21 @@
-// if you checked "fancy-settings" in extensionizr.com, uncomment this lines
+chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
+  	sendResponse({
+      'copy': function() {
+        var sandbox = document.getElementById('sandbox');
+        sandbox.value = request.value;
+        sandbox.select();
+        document.execCommand('copy');
+        sandbox.value = '';
+      },
+      '': function() {}
+    }[request['action']]());
+});
 
-// var settings = new Store("settings", {
-//     "sample_setting": "This is how you use Store.js to remember values"
-// });
-
-
-//example of using a message handler from the inject scripts
-chrome.extension.onMessage.addListener(
-  function(request, sender, sendResponse) {
-  	chrome.pageAction.show(sender.tab.id);
-    sendResponse();
-  });
+// copies str to clipboard - chrome.extension.getBackgroundPage().copy(str)
+function copy(str) {
+    var sandbox = document.getElementById('sandbox');
+    sandbox.value = str;
+    sandbox.select();
+    document.execCommand('copy');
+    sandbox.value = '';
+}

--- a/src/inject/inject.css
+++ b/src/inject/inject.css
@@ -1,3 +1,7 @@
-/**
- * Place your custom CSS styles here.
- **/
+.concourse-update-set-picker > div > .selector {
+    width: 300px;
+}
+
+.concourse-update-set-picker > div > .icon-document-multiple {
+    cursor: pointer;
+}

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -2,12 +2,47 @@ chrome.extension.sendMessage({}, function(response) {
 	var readyStateCheckInterval = setInterval(function() {
 	if (document.readyState === "complete") {
 		clearInterval(readyStateCheckInterval);
-
-		// ----------------------------------------------------------
-		// This part of the script triggers when page is done loading
-		console.log("Hello. This message was sent from scripts/inject.js");
-		// ----------------------------------------------------------
-
+		l('Document loaded, injecting scripts.');
+		try {
+			configureUpdateSetPicker();
+		} catch (e) {
+			l('Could not configure update set picker. ', e)
+		}
 	}
 	}, 10);
 });
+
+function configureUpdateSetPicker() {
+	var pickerIcon = $('.concourse-update-set-picker > div > .icon-document-multiple');
+	pickerIcon.click(function() {
+		var name = $('select#update_set_picker_select > option:selected')[0].label;
+		pickerIcon[0].classList.remove('icon-document-multiple');
+		pickerIcon[0].classList.add('icon-article-document');
+		setTimeout(function() {
+			pickerIcon[0].classList.remove('icon-article-document');
+			pickerIcon[0].classList.add('icon-document-multiple');
+		}, 200);
+		chrome.runtime.sendMessage({
+			'action': 'copy',
+			'value': /^(.*) \[.*\]$/g.exec(name)[1]
+		});
+	});
+	pickerIcon[0].title = 'Copy current update set to clipboard';
+	pickerIcon.before(function () {
+		var e = document.createElement('span');
+		e.classList.add('label-icon', 'icon-console');
+		e.style.marginRight = '10px';
+		e.style.cursor = 'pointer';
+		e.title = 'Go to current update set';
+		e.onclick = function() {
+			window.location.href = '/nav_to.do?uri=/sys_update_set.do?sys_id=' + 
+				$('select#update_set_picker_select > option:selected').val().split(':')[1];
+		}
+		return e;
+	})
+}
+
+function l(message, e) {
+	console.log('[MSGA] ' + message);
+	e ? console.log('[MSGA] Detail: ' + e) : {};
+}


### PR DESCRIPTION
![New update set picker](https://i.imgur.com/abhtP8Z.png)

* Click on the stacked paper icon on the right to copy the current update set name to the clipboard.
* Click on the caret icon on the left to go to the current update set in ServiceNow.
* Also, now the update set picker is 300px wide. Wide enough to see a name.